### PR TITLE
add a wrapper for macOS notifications API

### DIFF
--- a/examples/notifications.py
+++ b/examples/notifications.py
@@ -5,7 +5,7 @@ from datetype import aware
 from datetime import datetime
 from Foundation import NSLog
 from quickmacapp import Status, mainpoint, quit, answer
-from quickmacapp._notifications import Notifier, PList, configureNotifications, response
+from quickmacapp.notifications import Notifier, PList, configureNotifications, response
 from twisted.internet.defer import Deferred
 
 

--- a/examples/notifications.py
+++ b/examples/notifications.py
@@ -14,19 +14,14 @@ class category1:
     notificationID: str
     state: list[str]
 
-    @response.action(identifier="action1", title="First Action")
+    @response(identifier="action1", title="First Action")
     async def action1(self) -> None:
         """
         An action declared like so is a regular action that displays a button.
         """
         await answer(f"{self.notificationID}\nhere's an answer! {self.state}")
 
-    @response.text(
-        identifier="action2",
-        title="Text Action",
-        buttonTitle="Process Text",
-        textPlaceholder="hold place please",
-    )
+    @response(identifier="action2", title="Text Action").text()
     async def action2(self, text: str) -> None:
         """
         An action that takes a C{text} argument is registered as a
@@ -87,7 +82,7 @@ def app(reactor):
                 "Here's The Notification",
             )
 
-        async def doCancel()-> None:
+        async def doCancel() -> None:
             cat1notify.undeliver(category1(f"just.testing.{n}", ["ignored"]))
 
         cat1notify = await setupNotifications()

--- a/examples/notifications.py
+++ b/examples/notifications.py
@@ -19,7 +19,7 @@ class category1:
         """
         An action declared like so is a regular action that displays a button.
         """
-        await answer(f"here's an answer! {self.state}")
+        await answer(f"{self.notificationID}\nhere's an answer! {self.state}")
 
     @response.text(
         identifier="action2",
@@ -33,7 +33,7 @@ class category1:
         L{UNTextInputNotificationAction}, and that text is passed along in
         responses.
         """
-        await answer(f"got some text\n{text}\n{self.state}")
+        await answer(f"{self.notificationID}\ngot some text\n{text}\n{self.state}")
 
     @response.default()
     async def defaulted(self) -> None:
@@ -41,14 +41,14 @@ class category1:
         A user invoked the default response (i.e.: clicked on the
         notification).
         """
-        await answer(f"defaulted\n{self.state}")
+        await answer(f"{self.notificationID}\ndefaulted\n{self.state}")
 
     @response.dismiss()
     async def dismiss(self) -> None:
         """
         A user dismissed this notification.
         """
-        await answer(f"dismissed\n{self.state}")
+        await answer(f"{self.notificationID}\ndismissed\n{self.state}")
 
 
 @dataclass
@@ -83,12 +83,21 @@ def app(reactor):
             await cat1notify.notifyAt(
                 aware(datetime.now(ZoneInfo("US/Pacific")), ZoneInfo),
                 category1(f"just.testing.{n}", ["some", "words"]),
-                "Just Testing This Out",
+                f"Just Testing This Out ({n})",
                 "Here's The Notification",
             )
 
+        async def doCancel()-> None:
+            cat1notify.undeliver(category1(f"just.testing.{n}", ["ignored"]))
+
         cat1notify = await setupNotifications()
-        s.menu([("Notify", lambda: Deferred.fromCoroutine(doNotify())), ("Quit", quit)])
+        s.menu(
+            [
+                ("Notify", lambda: Deferred.fromCoroutine(doNotify())),
+                ("Cancel", lambda: Deferred.fromCoroutine(doCancel())),
+                ("Quit", quit),
+            ]
+        )
 
     Deferred.fromCoroutine(stuff())
 

--- a/examples/notifications.py
+++ b/examples/notifications.py
@@ -33,7 +33,7 @@ class category1:
         L{UNTextInputNotificationAction}, and that text is passed along in
         responses.
         """
-        await answer(f"got some text {text} {self.state}")
+        await answer(f"got some text\n{text}\n{self.state}")
 
     @response.default()
     async def defaulted(self) -> None:
@@ -41,14 +41,14 @@ class category1:
         A user invoked the default response (i.e.: clicked on the
         notification).
         """
-        await answer(f"defaulted {self.state}")
+        await answer(f"defaulted\n{self.state}")
 
     @response.dismiss()
     async def dismiss(self) -> None:
         """
         A user dismissed this notification.
         """
-        await answer(f"dismissed {self.state}")
+        await answer(f"dismissed\n{self.state}")
 
 
 @dataclass
@@ -56,10 +56,10 @@ class ExampleTranslator:
     txState: str
 
     def fromNotification(self, notificationID: str, userData: PList) -> category1:
-        return category1(notificationID, userData)
+        return category1(notificationID, userData["stateList"])
 
     def toNotification(self, notification: category1) -> tuple[str, PList]:
-        return (notification.notificationID, notification.state)
+        return (notification.notificationID, {"stateList": notification.state})
 
 
 async def setupNotifications() -> Notifier[category1]:

--- a/examples/notifications.py
+++ b/examples/notifications.py
@@ -3,9 +3,8 @@ from zoneinfo import ZoneInfo
 
 from datetype import aware
 from datetime import datetime
-from Foundation import NSLog
 from quickmacapp import Status, mainpoint, quit, answer
-from quickmacapp.notifications import Notifier, PList, configureNotifications, response
+from quickmacapp.notifications import Notifier, configureNotifications, response
 from twisted.internet.defer import Deferred
 
 
@@ -16,53 +15,36 @@ class category1:
 
     @response(identifier="action1", title="First Action")
     async def action1(self) -> None:
-        """
-        An action declared like so is a regular action that displays a button.
-        """
         await answer(f"{self.notificationID}\nhere's an answer! {self.state}")
 
     @response(identifier="action2", title="Text Action").text()
     async def action2(self, text: str) -> None:
-        """
-        An action that takes a C{text} argument is registered as a
-        L{UNTextInputNotificationAction}, and that text is passed along in
-        responses.
-        """
         await answer(f"{self.notificationID}\ngot some text\n{text}\n{self.state}")
 
     @response.default()
     async def defaulted(self) -> None:
-        """
-        A user invoked the default response (i.e.: clicked on the
-        notification).
-        """
         await answer(f"{self.notificationID}\ndefaulted\n{self.state}")
 
     @response.dismiss()
     async def dismiss(self) -> None:
-        """
-        A user dismissed this notification.
-        """
         await answer(f"{self.notificationID}\ndismissed\n{self.state}")
 
 
-@dataclass
 class ExampleTranslator:
-    txState: str
-
-    def fromNotification(self, notificationID: str, userData: PList) -> category1:
+    def fromNotification(
+        self, notificationID: str, userData: dict[str, list[str]]
+    ) -> category1:
         return category1(notificationID, userData["stateList"])
 
-    def toNotification(self, notification: category1) -> tuple[str, PList]:
+    def toNotification(
+        self, notification: category1
+    ) -> tuple[str, dict[str, list[str]]]:
         return (notification.notificationID, {"stateList": notification.state})
 
 
 async def setupNotifications() -> Notifier[category1]:
-    cat1txl = ExampleTranslator("hi")
-    NSLog("setting up notifications...")
     async with configureNotifications() as n:
-        cat1notify = n.add(category1, cat1txl)
-    NSLog("set up!")
+        cat1notify = n.add(category1, ExampleTranslator())
     return cat1notify
 
 

--- a/examples/notifications.py
+++ b/examples/notifications.py
@@ -1,0 +1,96 @@
+from dataclasses import dataclass
+from zoneinfo import ZoneInfo
+
+from datetype import aware
+from datetime import datetime
+from Foundation import NSLog
+from quickmacapp import Status, mainpoint, quit, answer
+from quickmacapp._notifications import Notifier, PList, configureNotifications, response
+from twisted.internet.defer import Deferred
+
+
+@dataclass
+class category1:
+    notificationID: str
+    state: list[str]
+
+    @response.action(identifier="action1", title="First Action")
+    async def action1(self) -> None:
+        """
+        An action declared like so is a regular action that displays a button.
+        """
+        await answer(f"here's an answer! {self.state}")
+
+    @response.text(
+        identifier="action2",
+        title="Text Action",
+        buttonTitle="Process Text",
+        textPlaceholder="hold place please",
+    )
+    async def action2(self, text: str) -> None:
+        """
+        An action that takes a C{text} argument is registered as a
+        L{UNTextInputNotificationAction}, and that text is passed along in
+        responses.
+        """
+        await answer(f"got some text {text} {self.state}")
+
+    @response.default()
+    async def defaulted(self) -> None:
+        """
+        A user invoked the default response (i.e.: clicked on the
+        notification).
+        """
+        await answer(f"defaulted {self.state}")
+
+    @response.dismiss()
+    async def dismiss(self) -> None:
+        """
+        A user dismissed this notification.
+        """
+        await answer(f"dismissed {self.state}")
+
+
+@dataclass
+class ExampleTranslator:
+    txState: str
+
+    def fromNotification(self, notificationID: str, userData: PList) -> category1:
+        return category1(notificationID, userData)
+
+    def toNotification(self, notification: category1) -> tuple[str, PList]:
+        return (notification.notificationID, notification.state)
+
+
+async def setupNotifications() -> Notifier[category1]:
+    cat1txl = ExampleTranslator("hi")
+    NSLog("setting up notifications...")
+    async with configureNotifications() as n:
+        cat1notify = n.add(category1, cat1txl)
+    NSLog("set up!")
+    return cat1notify
+
+
+@mainpoint()
+def app(reactor):
+    async def stuff() -> None:
+        s = Status("💁💬")
+        n = 0
+
+        async def doNotify() -> None:
+            nonlocal n
+            n += 1
+            await cat1notify.notifyAt(
+                aware(datetime.now(ZoneInfo("US/Pacific")), ZoneInfo),
+                category1(f"just.testing.{n}", ["some", "words"]),
+                "Just Testing This Out",
+                "Here's The Notification",
+            )
+
+        cat1notify = await setupNotifications()
+        s.menu([("Notify", lambda: Deferred.fromCoroutine(doNotify())), ("Quit", quit)])
+
+    Deferred.fromCoroutine(stuff())
+
+
+app.runMain()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,5 +14,6 @@ dependencies = [
     "pyobjc-framework-Cocoa",
     "pyobjc-framework-ExceptionHandling",
     "pyobjc-framework-UserNotifications",
+    "datetype",
     "twisted[tls,macos_platform]",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,8 @@ cryptography==44.0.2
     #   twisted
 cython-test-exception-raiser==1.0.2
     # via twisted
+datetype==2025.2.13
+    # via quickmacapp (pyproject.toml)
 h11==0.14.0
     # via httpcore
 h2==4.2.0

--- a/src/quickmacapp/_notifications.py
+++ b/src/quickmacapp/_notifications.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from contextlib import AbstractAsyncContextManager
+from dataclasses import dataclass
+from types import TracebackType
+from typing import Awaitable, Callable, Sequence
+
+from Foundation import NSError, NSLog, NSObject
+from objc import object_property
+from twisted.internet.defer import Deferred
+from UserNotifications import (
+    UNAuthorizationOptionNone,
+    UNNotificationAction,
+    UNNotificationActionOptionAuthenticationRequired,
+    UNNotificationActionOptionDestructive,
+    UNNotificationActionOptionForeground,
+    UNNotificationCategory,
+    UNNotificationCenterPresentationOptions,
+    UNNotificationPresentationOptionBanner,
+    UNNotificationCategoryOptionAllowInCarPlay,
+    UNNotificationCategoryOptionCustomDismissAction,
+    UNNotificationCategoryOptionHiddenPreviewsShowSubtitle,
+    UNNotificationCategoryOptionHiddenPreviewsShowTitle,
+    UNNotificationSettings,
+    UNTextInputNotificationAction,
+    UNUserNotificationCenter,
+    UNNotification,
+)
+
+
+@dataclass
+class AppNotificationAction:
+    """
+    An L{AppNotificationAction} is an action declared in the process of
+    building a L{AppNotificationsManager}.
+    """
+
+
+@dataclass
+class _AppNotificationsCtxBuilder:
+    center: UNUserNotificationCenter
+    mgr: AppNotificationsManager | None
+
+    async def __aenter__(self) -> AppNotificationsManager:
+        """
+        Request authorization, then start building this notifications manager.
+        """
+        grantDeferred: Deferred[bool] = Deferred()
+
+        def completed(granted: bool, error: NSError | None) -> None:
+            # TODO: convert non-None NSErrors into failures on this Deferred
+            NSLog("Requesting notification authorization...")
+            grantDeferred.callback(granted)
+            NSLog(
+                "Notification authorization response: %@ with error: %@", granted, error
+            )
+
+        self.center.requestAuthorizationWithOptions_completionHandler_(
+            UNAuthorizationOptionNone, grantDeferred
+        )
+        granted = await grantDeferred
+        settingsDeferred: Deferred[UNNotificationSettings]
+
+        def gotSettings(settings: UNNotificationSettings) -> None:
+            settingsDeferred.callback(settings)
+
+        self.center.getNotificationSettingsWithCompletionHandler_(gotSettings)
+        settings = await settingsDeferred
+        self.mgr = AppNotificationsManager(self.center, granted, settings, [], [])
+        return self.mgr
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+        /,
+    ) -> bool:
+        if traceback is None and self.mgr is not None:
+            self.center.setDelegate_(
+                AppNotificationsDelegateWrapper.alloc().initWithManager_(self.mgr)
+            )
+            self.center.setNotificationCategories_(
+                [each._unNotificationCategory for each in self.mgr._categories]
+            )
+        return False
+
+
+class AppNotificationsDelegateWrapper(NSObject):
+    manager: AppNotificationsManager = object_property()
+
+    def initWithManager_(self, mgr: AppNotificationsManager) -> None:
+        self.manager = mgr
+
+    def userNotificationCenter_willPresentNotification_withCompletionHandler_(
+        self,
+        notificationCenter: UNUserNotificationCenter,
+        notification: UNNotification,
+        completionHandler: Callable[[UNNotificationCenterPresentationOptions], None],
+    ) -> None:
+        completionHandler(UNNotificationPresentationOptionBanner)
+
+
+
+@dataclass
+class AppNotificationsAction:
+    identifier: str
+    _mgr: AppNotificationsManager
+    _unNotificationAction: UNNotificationAction
+
+
+@dataclass
+class AppNotificationsCategory:
+    identifier: str
+    actions: Sequence[tuple[AppNotificationsAction, Callable[[str], Awaitable[None]]]]
+    intentIdentifiers: Sequence[str]
+    _unNotificationCategory: UNNotificationCategory
+
+
+@dataclass
+class TextInput:
+    buttonTitle: str
+    textPlaceholder: str
+
+
+@dataclass
+class AppNotificationsManager:
+    """
+    An L{AppNotificationsManager} can emit local notifications to the user and
+    configure the application's response to the user interacting with those
+    notifications.
+    """
+
+    _center: UNUserNotificationCenter
+    _granted: bool
+    _settings: UNNotificationSettings
+    _actions: list[AppNotificationsAction]
+    _categories: list[AppNotificationsCategory]
+
+    def action(
+        self,
+        *,
+        identifier: str,
+        title: str,
+        foreground: bool = False,
+        destructive: bool = False,
+        authenticationRequired: bool = False,
+        textInput: TextInput | None = None,
+    ) -> AppNotificationsAction:
+        # TODO: support for 'icon' parameter
+
+        # compose options
+        options = 0
+        if foreground:
+            options |= UNNotificationActionOptionForeground
+        if destructive:
+            options |= UNNotificationActionOptionDestructive
+        if authenticationRequired:
+            options |= UNNotificationActionOptionAuthenticationRequired
+
+        if textInput is not None:
+            textInputButtonTitle = textInput.buttonTitle
+            textInputPlaceholder = textInput.textPlaceholder
+            uiAction = UNTextInputNotificationAction.actionWithIdentifier_title_options_textInputButtonTitle_textInputPlaceholder_(
+                identifier, title, options, textInputButtonTitle, textInputPlaceholder
+            )
+        else:
+            uiAction = UNNotificationAction.actionWithIdentifier_title_options_(
+                identifier, title, options
+            )
+        self._actions.append(
+            action := AppNotificationsAction(
+                identifier,
+                self,
+                uiAction,
+            )
+        )
+        return action
+
+    def category(
+        self,
+        *,
+        identifier: str,
+        actions: Sequence[
+            tuple[AppNotificationsAction, Callable[[str], Awaitable[None]]]
+        ],
+        activated: Callable[[str], Awaitable[None]],
+        allowInCarPlay: bool = False,
+        hiddenPreviewsShowTitle: bool = False,
+        hiddenPreviewsShowSubtitle: bool = False,
+        customDismissAction: bool = False,
+    ) -> AppNotificationsCategory:
+        # Something to do with SiriKit, but we don't know what.
+        intentIdentifiers: list[str] = []
+        options = 0
+        if allowInCarPlay:
+            # Ha ha. Someday, maybe.
+            options |= UNNotificationCategoryOptionAllowInCarPlay
+        if hiddenPreviewsShowTitle:
+            options |= UNNotificationCategoryOptionHiddenPreviewsShowTitle
+        if hiddenPreviewsShowSubtitle:
+            options |= UNNotificationCategoryOptionHiddenPreviewsShowSubtitle
+        if customDismissAction:
+            options |= UNNotificationCategoryOptionCustomDismissAction
+        self._categories.append(
+            result := AppNotificationsCategory(
+                identifier=identifier,
+                actions=actions,
+                intentIdentifiers=intentIdentifiers,
+                _unNotificationCategory=UNNotificationCategory.categoryWithIdentifier_actions_intentIdentifiers_options_(
+                    identifier,
+                    [action._unNotificationAction for (action, cb) in actions],
+                    intentIdentifiers,
+                    options,
+                ),
+            )
+        )
+        return result
+
+
+def configureNotifications() -> AbstractAsyncContextManager[AppNotificationsManager]:
+    return _AppNotificationsCtxBuilder(
+        UNUserNotificationCenter.currentNotificationCenter(), None
+    )
+
+
+async def setupNotificationsExample() -> None:
+    async with configureNotifications() as n:
+        action1 = n.action(identifier="action1", title="Action 1")
+
+        # Every notification needs to have a category identifier in order to be
+        # presented.  Notifications within a category thus have a natural
+        # association with some logic to execute as a (categoryIdentifier,
+        # actionIdentifier) tuple, taking the notification's own identifier
+        # itself as an argument, to look up any associated persistent data that
+        # may exist across app launches.  There are also the *implied* actions
+        # of UNNotificationDefaultActionIdentifier and
+        # UNNotificationDismissActionIdentifier, for when the user just clicks
+        # on a notification and for when the user dismisses the notification.
+        # To make the illegal states unrepresentable here, we need to have a
+        # structure like...
+
+        async def action1category1(notificationIdentifier: str) -> None:
+            pass
+
+        async def action1activated(notificationIdentifier: str) -> None:
+            pass
+
+        n.category(
+            identifier="category1",
+            # If you want to specify an action, you _must_ supply a paired callback.
+            actions=[(action1, action1category1)],
+            activated=action1activated,
+        )

--- a/src/quickmacapp/_notifications.py
+++ b/src/quickmacapp/_notifications.py
@@ -318,6 +318,22 @@ class Notifier[NotifT]:
         )
         await d
 
+    def undeliver(self, notification: NotifT) -> None:
+        """
+        Remove the previously-delivered notification object from the
+        notification center, if it's still there.
+        """
+        notID, _ = self._tx.toNotification(notification)
+        self._cfg._center.removeDeliveredNotificationsWithIdentifiers_([notID])
+
+    def unsend(self, notification: NotifT) -> None:
+        """
+        Prevent the as-yet undelivered notification object from being
+        delivered.
+        """
+        notID, _ = self._tx.toNotification(notification)
+        self._cfg._center.removePendingNotificationRequestsWithIdentifiers_([notID])
+
     async def notifyAt(
         self, when: DateTime[ZoneInfo], notification: NotifT, title: str, body: str
     ) -> None:
@@ -377,7 +393,7 @@ class NotificationConfig:
 
         @param translator: a translator that can load and save a translator.
         """
-        catid: str = category.__name__
+        catid: str = f"{category.__module__}.{category.__qualname__}"
         notifier = Notifier(
             catid,
             self,

--- a/src/quickmacapp/_notifications.py
+++ b/src/quickmacapp/_notifications.py
@@ -106,7 +106,9 @@ class _AppNotificationsCtxBuilder:
 class _QMANotificationDelegateWrapper(NSObject):
     config: NotificationConfig = object_property()
 
-    def initWithConfig_(self, cfg: NotificationConfig) -> _QMANotificationDelegateWrapper:
+    def initWithConfig_(
+        self, cfg: NotificationConfig
+    ) -> _QMANotificationDelegateWrapper:
         self.config = cfg
         return self
 
@@ -134,14 +136,23 @@ class _QMANotificationDelegateWrapper(NSObject):
         We received a response to a notification.
         """
         NSLog("received notification repsonse %@", notificationResponse)
+
         # TODO: actually hook up the dispatch of the notification response to
         # the registry of action callbacks already set up in
         # NotificationConfig.
         async def respond() -> None:
-            notifier = self.config._notifierByCategory(notificationResponse.notification().request().content().categoryIdentifier())
+            notifier = self.config._notifierByCategory(
+                notificationResponse.notification()
+                .request()
+                .content()
+                .categoryIdentifier()
+            )
             await notifier._handleResponse(notificationResponse)
             completionHandler()
-        Deferred.fromCoroutine(respond()).addErrback(lambda error: NSLog("error: %@", error))
+
+        Deferred.fromCoroutine(respond()).addErrback(
+            lambda error: NSLog("error: %@", error)
+        )
 
 
 def configureNotifications() -> AbstractAsyncContextManager[NotificationConfig]:
@@ -178,7 +189,10 @@ def configureNotifications() -> AbstractAsyncContextManager[NotificationConfig]:
     )
 
 
-type PList = Any
+type PList = dict[
+    str,
+    Any,
+]
 
 
 # framework
@@ -227,8 +241,10 @@ class Notifier[NotifT]:
     _hiddenPreviewsShowTitle: bool
     _hiddenPreviewsShowSubtitle: bool
 
-    def _getActionCB(self, actionID: str) -> Callable[[Any, UNNotificationResponse], Awaitable[None]]:
-        for (cb, eachActionID, action, options) in self._actionInfos:
+    def _getActionCB(
+        self, actionID: str
+    ) -> Callable[[Any, UNNotificationResponse], Awaitable[None]]:
+        for cb, eachActionID, action, options in self._actionInfos:
             if actionID == eachActionID:
                 return cb
         raise KeyError(actionID)
@@ -630,4 +646,3 @@ class response:
             return wrapt
 
         return deco
-

--- a/src/quickmacapp/_notifications.py
+++ b/src/quickmacapp/_notifications.py
@@ -162,25 +162,18 @@ class _QMANotificationDelegateWrapper(NSObject):
         )
 
 
-type PList = dict[
-    str,
-    Any,
-]
-
-
-# framework
 class NotificationTranslator[T](Protocol):
     """
     Translate notifications from the notification ID and some user data,
     """
 
-    def fromNotification(self, notificationID: str, userData: PList) -> T:
+    def fromNotification(self, notificationID: str, userData: dict[str, Any]) -> T:
         """
         A user interacted with a notification with the given parameters;
         deserialize them into a Python object that can process that action.
         """
 
-    def toNotification(self, notification: T) -> tuple[str, PList]:
+    def toNotification(self, notification: T) -> tuple[str, dict[str, Any]]:
         """
         The application has requested to send a notification to the operating
         system, serialize the Python object represneting this category of

--- a/src/quickmacapp/notifications.py
+++ b/src/quickmacapp/notifications.py
@@ -1,0 +1,186 @@
+"""
+API for emitting macOS notifications.
+
+@see: L{configureNotifications}.
+"""
+
+from contextlib import AbstractAsyncContextManager as _AbstractAsyncContextManager
+from dataclasses import dataclass as _dataclass
+from typing import Callable, Protocol
+from zoneinfo import ZoneInfo
+
+from datetype import DateTime
+from UserNotifications import (
+    UNNotificationCategoryOptionCustomDismissAction as _UNNotificationCategoryOptionCustomDismissAction,
+    UNUserNotificationCenter as _UNUserNotificationCenter,
+    UNNotificationDefaultActionIdentifier as _UNNotificationDefaultActionIdentifier,
+    UNNotificationDismissActionIdentifier as _UNNotificationDismissActionIdentifier,
+)
+
+from quickmacapp._notifications import (
+    NotificationTranslator,
+    PList,
+    _BuiltinActionInfo,
+    _PlainNotificationActionInfo,
+    _setActionInfo,
+    _TextNotificationActionInfo,
+    _AppNotificationsCtxBuilder,
+)
+
+__all__ = [
+    "NotificationTranslator",
+    "PList",
+    "Action",
+    "TextAction",
+    "response",
+    "Notifier",
+    "NotificationConfig",
+]
+
+
+class Action[NotificationT](Protocol):
+    """
+    An action is just an async method that takes its C{self} (an instance of a
+    notification class encapsulating the ID & data), and reacts to the
+    specified action.
+    """
+
+    async def __call__(__no_self__, /, self: NotificationT) -> None:
+        """
+        React to the action.
+        """
+
+
+class TextAction[NotificationT](Protocol):
+    """
+    A L{TextAction} is just like an L{Action}, but it takes some text.
+    """
+
+    async def __call__(__no_self__, /, self: NotificationT, text: str) -> None:
+        """
+        React to the action with the user's input.
+        """
+
+
+@_dataclass
+class response:
+    identifier: str
+    title: str
+    foreground: bool = False
+    destructive: bool = False
+    authenticationRequired: bool = False
+
+    def __call__[NT](self, action: Action[NT], /) -> Action[NT]:
+        return _setActionInfo(
+            action,
+            _PlainNotificationActionInfo(
+                identifier=self.identifier,
+                title=self.title,
+                foreground=self.foreground,
+                destructive=self.destructive,
+                authenticationRequired=self.authenticationRequired,
+            ),
+        )
+
+    def text[NT](
+        self, *, title: str | None = None, placeholder: str = ""
+    ) -> Callable[[TextAction[NT]], TextAction[NT]]:
+        return lambda wrapt: _setActionInfo(
+            wrapt,
+            _TextNotificationActionInfo(
+                identifier=self.identifier,
+                title=self.title,
+                buttonTitle=title if title is not None else self.title,
+                textPlaceholder=placeholder,
+                foreground=self.foreground,
+                destructive=self.destructive,
+                authenticationRequired=self.authenticationRequired,
+            ),
+        )
+
+    @staticmethod
+    def default[NT]() -> Callable[[Action[NT]], Action[NT]]:
+        return lambda wrapt: _setActionInfo(
+            wrapt, _BuiltinActionInfo(_UNNotificationDefaultActionIdentifier, 0)
+        )
+
+    @staticmethod
+    def dismiss[NT]() -> Callable[[Action[NT]], Action[NT]]:
+        return lambda wrapt: _setActionInfo(
+            wrapt,
+            _BuiltinActionInfo(
+                _UNNotificationDismissActionIdentifier,
+                _UNNotificationCategoryOptionCustomDismissAction,
+            ),
+        )
+
+
+class Notifier[NotifT](Protocol):
+    """
+    A L{Notifier} can deliver notifications.
+    """
+
+    async def notifyAt(
+        self, when: DateTime[ZoneInfo], notification: NotifT, title: str, body: str
+    ) -> None:
+        """
+        Request a future notification at the given time.
+        """
+
+    def undeliver(self, notification: NotifT) -> None:
+        """
+        Remove the previously-delivered notification object from the
+        notification center, if it's still there.
+        """
+
+    def unsend(self, notification: NotifT) -> None:
+        """
+        Prevent the as-yet undelivered notification object from being
+        delivered.
+        """
+
+
+class NotificationConfig(Protocol):
+
+    def add[NotifT](
+        self,
+        category: type[NotifT],
+        translator: NotificationTranslator[NotifT],
+        allowInCarPlay: bool = False,
+        hiddenPreviewsShowTitle: bool = False,
+        hiddenPreviewsShowSubtitle: bool = False,
+    ) -> Notifier[NotifT]: ...
+
+
+def configureNotifications() -> _AbstractAsyncContextManager[NotificationConfig]:
+    """
+    Configure notifications for the current application, in a context manager.
+
+    This is in a context manager to require the setup to happen at the end with
+    the given list of categories.  Use like so::
+
+        class A:
+            id: str
+
+            @response.default()
+            async def activated(self) -> None:
+                print(f"user clicked {self.id}")
+
+        async def buildNotifiers(
+            appSpecificNotificationsDB: YourClass
+        ) -> tuple[Notifier[A], Notifier[B]]:
+            with configureNotifications() as cfg:
+                return (cfg.add(A, ATranslator(appSpecificNotificationsDB)),
+                        cfg.add(B, BTranslator(appSpecificNotificationsDB)))
+
+    and then in your application, in a startup hook like
+    applicationDidFinishLaunching_ or similar ::
+
+        def someSetupEvent_(whatever: NSObject) -> None:
+            async def setUpNotifications() -> None:
+                self.notifierA, self.notifierB = await buildNotifiers()
+            Deferred.fromCoroutine(setUpNotifications())
+    """
+    return _AppNotificationsCtxBuilder(
+        _UNUserNotificationCenter.currentNotificationCenter(), None
+    )

--- a/src/quickmacapp/notifications.py
+++ b/src/quickmacapp/notifications.py
@@ -19,7 +19,6 @@ from UserNotifications import (
 
 from quickmacapp._notifications import (
     NotificationTranslator,
-    PList,
     _BuiltinActionInfo,
     _PlainNotificationActionInfo,
     _setActionInfo,
@@ -29,7 +28,6 @@ from quickmacapp._notifications import (
 
 __all__ = [
     "NotificationTranslator",
-    "PList",
     "Action",
     "TextAction",
     "response",


### PR DESCRIPTION
The goal here is to use Python's types to make a more discoverable / harder to screw up workflow for setting notification categories and actions.